### PR TITLE
Add flags for flexible output of directory structure and file contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CodeMarkdownForGPT
 
-When working with chatGPT as a code-writing assistant, sometimes we need to share the code with him. Project Snapshot is
+When working with chatGPT as a code-writing assistant, sometimes we need to share the code with it. Project Snapshot is
 a script that allows you to output the content of specified file types along with an optional directory structure from
 the terminal. It's a handy tool for quickly reviewing or sharing the current state of your project's codebase.
 
@@ -32,6 +32,7 @@ To use Project Snapshot, you need to have Zsh installed on your machine.
 ### Options
 
 - `-s`: Include directory structure in the output.
+- `-f`: Include file contents for specified file types in the output.
 
 ### File Types
 
@@ -41,10 +42,13 @@ Specify the file types you want to include in the output by their extensions, se
 
 ```bash
 # Output the content of all .js and .css files
-./project_snapshot.sh js css
+./project_snapshot.sh -f js css
+
+# Output the directory structure only
+./project_snapshot.sh -s
 
 # Output the content of all .py files and include the directory structure
-./project_snapshot.sh -s py
+./project_snapshot.sh -s -f py
 ```
 
 ## Integrating with Zsh

--- a/snippet-and-structure-exporter.sh
+++ b/snippet-and-structure-exporter.sh
@@ -1,18 +1,25 @@
+#!/bin/bash
+
 # Function to process command line options
 process_options() {
-  while getopts ":s" opt; do
+  while getopts ":sf" opt; do
     case ${opt} in
       s )
-        # Set flag
+        # Set flag for structure
         structure=true
         ;;
+      f )
+        # Set flag for file contents
+        files=true
+        ;;
       \? )
-        echo "Usage: outputCode [-s] filetypes"
-        return
+        echo "Usage: outputCode [-s] [-f] filetypes"
+        exit 1
         ;;
     esac
   done
   shift $((OPTIND -1))
+  fileTypes=("$@")  # Get the remaining arguments as file types
 }
 
 # Function to build the prune command for find
@@ -49,22 +56,30 @@ output_directory_structure() {
     eval "tree -a --dirsfirst $excludeOption"
 }
 
+# Main function to handle project snapshot
 project_snapshot() {
-  # Get file types from parameters
-  fileTypes=("$@")
-  # Flag for directory structure
+  # Flags for directory structure and file contents
   structure=false
-  # Directories to exclude - use space to separate them ("venv" "anotherDir" "yetAnotherDir")
+  files=false
+  # Directories to exclude - use space to separate them ("venv" ".git" ".idea")
   excludeDirs=("venv" ".git" ".idea")
   # Build the prune command for find
   pruneCmd=()
 
+  # Process options and file types
   process_options "$@"
   build_prune_command
-  output_file_content
 
   # Output directory structure if -s flag is provided
   if $structure; then
     output_directory_structure
   fi
+
+  # Output file contents if -f flag is provided
+  if $files; then
+    output_file_content
+  fi
 }
+
+# Run the project_snapshot function with the provided arguments
+project_snapshot "$@"


### PR DESCRIPTION
- Added -s flag to output directory structure.
- Added -f flag to output file contents for specified file types.
- Users can now selectively print the directory structure, file contents, or both.

https://chatgpt.com/c/5fa60155-7b66-443a-a3cc-b4b34042e339